### PR TITLE
fix: guard Contact::setPrimary for contacts without company

### DIFF
--- a/backend/app/Models/Contact.php
+++ b/backend/app/Models/Contact.php
@@ -102,9 +102,14 @@ class Contact extends Model
      */
     public function setPrimary(): void
     {
+        // If this contact is not associated with a company, there is nothing to update
+        if (!$this->company) {
+            return;
+        }
+
         // First, unset all other primary contacts for this company
         $this->company->contacts()->where('id', '!=', $this->id)->update(['is_primary' => false]);
-        
+
         // Then set this contact as primary
         $this->update(['is_primary' => true]);
     }


### PR DESCRIPTION
## Summary
- prevent errors when marking a contact as primary if it isn't linked to a company

## Testing
- `php -l backend/app/Models/Contact.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6890ecc87b90832ea5d7046f373f38ae